### PR TITLE
#159784926 Build endpoint to accept answer

### DIFF
--- a/server/controllers/index.js
+++ b/server/controllers/index.js
@@ -109,3 +109,26 @@ export const postAnswer = (req, res) => {
     });
   }
 };
+
+/**
+ * Middleware: PATCHES(accepts) a specific answer to a question
+ * Responds with the appropriate error/success status and message.
+ * @param {object} req - query request
+ * @param {object} res - query response
+ * @returns {void}
+*/
+export const acceptAnswer = (req, res) => {
+  const index = getIndexById(req.params.answerId, req.question.answers);
+  const answer = req.question.answers[index];
+
+  if (answer) {
+    answer.accept = true;
+    res.status(200).json({
+      status: 'success',
+      message: 'answer succesfully accepted',
+      answer,
+    });
+  } else {
+    res.status(404).send(`answer with id= ${req.params.answerId}, to question with id= ${req.params.questionId} not found`);
+  }
+};

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -5,6 +5,7 @@ import {
   validQuestion,
   postQuestion,
   postAnswer,
+  acceptAnswer,
 } from '../controllers';
 
 const router = express.Router();
@@ -17,5 +18,7 @@ router.get('/v1/questions/:questionId', getOneQuestion);
 
 router.post('/v1/questions', postQuestion);
 router.post('/v1/questions/:questionId/answers', postAnswer);
+
+router.patch('/v1/questions/:questionId/answers/:answerId', acceptAnswer);
 
 export default router;

--- a/server/spec/controllers/patch.spec.js
+++ b/server/spec/controllers/patch.spec.js
@@ -1,0 +1,35 @@
+import Request from 'request';
+import {
+  answerInput,
+} from '../testUtils';
+
+describe('PATCH ROUTE', () => {
+// PATCH ACCEPT AN ANSWER
+  describe('to accept an answer', () => {
+    const data = {};
+    // add an answer
+    beforeAll((done) => {
+      Request({ url: 'http://localhost:4001/v1/questions/1/answers', method: 'POST', json: answerInput }, (error, response, body) => {
+        done();
+      });
+    });
+    // accept the answer
+    beforeAll((done) => {
+      Request.patch('http://localhost:4001/v1/questions/1/answers/1', (error, response, body) => {
+        data.status = response.statusCode;
+        data.answer = JSON.parse(body).answer;
+        done();
+      });
+    });
+
+    it('has status 404', () => {
+      expect(data.status).toBe(200);
+    });
+
+    it('has a body of', () => {
+      expect(data.answer.body).toBe(answerInput.body);
+      expect(data.answer.user).toBe(answerInput.user);
+      expect(data.answer.accept).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
### **What does this PR do?**
Implement the Patch one answer API endpoint to accept an answer.

### **Description of Tasks to be completed?**
- API should be able to accept a single answer when endpoint `PATCH /v1/questions/:questionId/answers/:answerId` is hit

### **How should this be manually tested?**
- Clone the repository
- Cd into it
- Checkout the **ft-accept-answer-endpoint-159784926**  branch
- Run the following `npm install`, then `npm run nodemon` 
- Use postman to test the endpoint using 
    - `POST` at http://localhost:4001/v1/questions/:questionId/answers to post an answer
    - `PATCH` at http://localhost:4001/v1/questions/:questionId/answers/:answerId to accept the answer

### **What are relevant pivotal tracker stories?**
[#159784926](https://www.pivotaltracker.com/n/projects/2189137)

