### PR TITLE
#159784920 Build endpoint to edit a question

### DIFF
--- a/server/controllers/index.js
+++ b/server/controllers/index.js
@@ -5,10 +5,12 @@ import {
   getIndexById,
   createQuestion,
   createAnswer,
+  updatePost,
 } from './utils';
 
 // validation functions
 import {
+  validateUpdate,
   validatePost,
 } from './validateUtils';
 
@@ -130,5 +132,31 @@ export const acceptAnswer = (req, res) => {
     });
   } else {
     res.status(404).send(`answer with id= ${req.params.answerId}, to question with id= ${req.params.questionId} not found`);
+  }
+};
+
+/**
+ * Middleware: PATCHES(edits) a specific question
+ * Validates request body.
+ * Responds with the appropriate error/success status and message.
+ * @param {object} req - query request
+ * @param {object} res - query response
+ * @returns {void}
+*/
+export const editQuestion = (req, res) => {
+  const { error } = validateUpdate(req.body);
+  if (error) {
+    res.status(400).send(error.details[0].message);
+  } else {
+    const update = updatePost(req.question, req.body);
+    if (update === 0) {
+      res.status(400).send('Invalid update request');
+    } else {
+      res.status(200).json({
+        status: 'success',
+        message: 'Question succesfully updated',
+        update,
+      });
+    }
   }
 };

--- a/server/controllers/utils.js
+++ b/server/controllers/utils.js
@@ -94,3 +94,34 @@ export const seedPosts = (postType, arr) => {
       console.log(`Invalid post type: ${postType}`);
   }
 };
+
+/**
+  * updates a post.
+  * @param {Post} post the post to be updated.
+  * @param {object} requestBody object containing update attribute
+  * @returns {Post} the updated post or 0 for failure
+  */
+export const updatePost = (post, requestBody) => {
+  switch (requestBody.attribute) {
+    case 'score':
+      if (requestBody.value === 'increment') {
+        post.plusScore();
+      } else if (requestBody.value === 'decrement') {
+        post.minusScore();
+      } else {
+        return 0;
+      }
+      break;
+      /* eslint-disable no-param-reassign */
+    case 'title':
+      post.title = requestBody.value;
+      break;
+    case 'body':
+      post.body = requestBody.value;
+      break;
+      /* eslint-disable no-param-reassign */
+    default:
+      return 0;
+  }
+  return post;
+};

--- a/server/controllers/validateUtils.js
+++ b/server/controllers/validateUtils.js
@@ -13,3 +13,17 @@ export const validatePost = (post) => {
   };
   return Joi.validate(post, schema);
 };
+
+/**
+ * validates the body of an input(PATCH).
+ * @param {object} update - The input body from a PATCH route.
+ * @returns {object} Joi.validate output
+*/
+export const validateUpdate = (update) => {
+  const schema = Joi.object().keys({
+    attribute: Joi.any().valid(['score', 'title', 'body']).required(),
+    value: Joi.string().required(),
+  }).and('attribute', 'value');
+
+  return Joi.validate(update, schema);
+};

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -6,6 +6,7 @@ import {
   postQuestion,
   postAnswer,
   acceptAnswer,
+  editQuestion,
 } from '../controllers';
 
 const router = express.Router();
@@ -20,5 +21,6 @@ router.post('/v1/questions', postQuestion);
 router.post('/v1/questions/:questionId/answers', postAnswer);
 
 router.patch('/v1/questions/:questionId/answers/:answerId', acceptAnswer);
+router.patch('/v1/questions/:questionId', editQuestion);
 
 export default router;

--- a/server/spec/controllers/patch.spec.js
+++ b/server/spec/controllers/patch.spec.js
@@ -1,6 +1,13 @@
 import Request from 'request';
 import {
   answerInput,
+  updateScorePlus,
+  updateScoreMinus,
+  invalidUpdateScore,
+  updateTitle,
+  updateBody,
+  invalidUpdate,
+  validId,
 } from '../testUtils';
 
 describe('PATCH ROUTE', () => {
@@ -30,6 +37,142 @@ describe('PATCH ROUTE', () => {
       expect(data.answer.body).toBe(answerInput.body);
       expect(data.answer.user).toBe(answerInput.user);
       expect(data.answer.accept).toBe(true);
+    });
+  });
+
+  // UPDATE score: increment QUESTION SCORE
+  describe('to increment a question\'s score', () => {
+    const dataScorePlus = {};
+    beforeAll((done) => {
+      Request({ url: `http://localhost:4001/v1/questions/${validId}`, method: 'PATCH', json: updateScorePlus }, (error, response, body) => {
+        dataScorePlus.status = response.statusCode;
+        dataScorePlus.update = body.update;
+        done();
+      });
+    });
+
+    afterAll((done) => {
+      Request({ url: `http://localhost:4001/v1/questions/${validId}`, method: 'PATCH', json: updateScoreMinus }, (error, response, body) => {
+        done();
+      });
+    });
+
+    it('has correct status code', () => {
+      expect(dataScorePlus.status).toBe(200);
+    });
+
+    it('has updated properly', () => {
+      // increment
+      expect(Number(dataScorePlus.update.score)).toBe(1);
+    });
+  });
+
+  // UPDATE score: decrement QUESTION SCORE
+  describe('to decrement question\'s score', () => {
+    const dataScoreMinus = {};
+    beforeAll((done) => {
+      Request({ url: `http://localhost:4001/v1/questions/${validId}`, method: 'PATCH', json: updateScoreMinus }, (error, response, body) => {
+        dataScoreMinus.status = response.statusCode;
+        dataScoreMinus.update = body.update;
+        done();
+      });
+    });
+
+    afterAll((done) => {
+      Request({ url: `http://localhost:4001/v1/questions/${validId}`, method: 'PATCH', json: updateScorePlus }, (error, response, body) => {
+        done();
+      });
+    });
+
+    it('has correct status code', () => {
+      expect(dataScoreMinus.status).toBe(200);
+    });
+
+    it('has updated properly', () => {
+      // decrement
+      expect(Number(dataScoreMinus.update.score)).toBe(-1);
+    });
+  });
+
+  // UPDATE score with INVALID VALUE
+  describe('to update question score with an invalid input', () => {
+    const dataScorePlus = {};
+    beforeAll((done) => {
+      Request({ url: `http://localhost:4001/v1/questions/${validId}`, method: 'PATCH', json: invalidUpdateScore }, (error, response, body) => {
+        dataScorePlus.status = response.statusCode;
+        dataScorePlus.body = body;
+        done();
+      });
+    });
+
+    it('has correct status code', () => {
+      expect(dataScorePlus.status).toBe(400);
+    });
+
+    it('has correct error message', () => {
+      expect(dataScorePlus.body).toBe('Invalid update request');
+    });
+  });
+
+  // UPDATE QUESTION BODY
+  describe('to update the body of a question', () => {
+    const dataBody = {};
+    beforeAll((done) => {
+      Request({ url: `http://localhost:4001/v1/questions/${3}`, method: 'PATCH', json: updateBody }, (error, response, body) => {
+        dataBody.status = response.statusCode;
+        dataBody.update = body.update;
+        done();
+      });
+    });
+
+    it('has correct status code', () => {
+      expect(dataBody.status).toBe(200);
+    });
+
+    it('has updated properly', () => {
+      // update Body
+      expect(dataBody.update.body).toBe(updateBody.value);
+    });
+  });
+
+  // UPDATE QUESTION TITLE
+  describe('to update the title of a question', () => {
+    const dataTitle = {};
+    beforeAll((done) => {
+      Request({ url: `http://localhost:4001/v1/questions/${3}`, method: 'PATCH', json: updateTitle }, (error, response, body) => {
+        dataTitle.status = response.statusCode;
+        dataTitle.update = body.update;
+        done();
+      });
+    });
+
+    it('has correct status code', () => {
+      expect(dataTitle.status).toBe(200);
+    });
+
+    it('has updated properly', () => {
+      // update Title
+      expect(dataTitle.update.title).toBe(updateTitle.value);
+    });
+  });
+
+  // UPDATE QUESTION WITH INVALID INPUTS
+  describe('to update a question with invalid inputs', () => {
+    const dataTitle = {};
+    beforeAll((done) => {
+      Request({ url: `http://localhost:4001/v1/questions/${3}`, method: 'PATCH', json: invalidUpdate }, (error, response, body) => {
+        dataTitle.status = response.statusCode;
+        dataTitle.update = body.update;
+        done();
+      });
+    });
+
+    it('has status correct status code', () => {
+      expect(dataTitle.status).toBe(400);
+    });
+
+    it('has no update', () => {
+      expect(dataTitle.update).toBe(undefined);
     });
   });
 });

--- a/server/spec/testUtils.js
+++ b/server/spec/testUtils.js
@@ -21,3 +21,33 @@ export const answerInput = {
 
 export const invalidId = 'sk';
 export const validId = '1';
+
+export const updateScorePlus = {
+  attribute: 'score',
+  value: 'increment',
+};
+
+export const updateScoreMinus = {
+  attribute: 'score',
+  value: 'decrement',
+};
+
+export const invalidUpdateScore = {
+  attribute: 'score',
+  value: 'excrement',
+};
+
+export const updateTitle = {
+  attribute: 'title',
+  value: 'test update title string',
+};
+
+export const updateBody = {
+  attribute: 'body',
+  value: 'test update body string',
+};
+
+export const invalidUpdate = {
+  attribute: 'xD',
+  value: 'LOL',
+};


### PR DESCRIPTION
### **What does this PR do?**
Implement the GET one question API endpoint.

### **Description of Tasks to be completed?**
- API should be able to edit a single question when endpoint `PATCH /v1/questions/:questionId` is hit

### **How should this be manually tested?**
- Clone the repository
- Cd into it
- Checkout the **ft-edit-question-endpoint-159784920**  branch
- Run the following `npm install`, then `npm run nodemon` 
- Use postman to test the endpoint using `PATCH` at http://localhost:4001/v1/questions/:questionId with a json body of the format below
```
{
	"attribute": "score",
	"value": "increment"
}
```
- if **attribute** is _score_, then _value_ can be '_increment_' or '_decrement_' to upvote/downvote respectively.
- if **attribute** is title or body, value should be whatever new string to replace.


### **What are relevant pivotal tracker stories?**
[#159784920](https://www.pivotaltracker.com/n/projects/2189137)

