### PR TITLE
#159784945 Build delete endpoint

### DIFF
--- a/server/controllers/index.js
+++ b/server/controllers/index.js
@@ -160,3 +160,15 @@ export const editQuestion = (req, res) => {
     }
   }
 };
+
+/**
+ * Middleware: DELETES a specific question.
+ * Responds with the appropriate status.
+ * @param {object} req - query request
+ * @param {object} res - query response
+ * @returns {void}
+*/
+export const deleteQuestion = (req, res) => {
+  questionList.splice(req.index, 1);
+  res.status(204).send();
+};

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -7,6 +7,7 @@ import {
   postAnswer,
   acceptAnswer,
   editQuestion,
+  deleteQuestion,
 } from '../controllers';
 
 const router = express.Router();
@@ -22,5 +23,6 @@ router.post('/v1/questions/:questionId/answers', postAnswer);
 
 router.patch('/v1/questions/:questionId/answers/:answerId', acceptAnswer);
 router.patch('/v1/questions/:questionId', editQuestion);
+router.delete('/v1/questions/:questionId', deleteQuestion);
 
 export default router;

--- a/server/spec/controllers/delete.spec.js
+++ b/server/spec/controllers/delete.spec.js
@@ -1,0 +1,23 @@
+import Request from 'request';
+
+describe('DELETE ROUTE', () => {
+// DELETE A QUESTION
+  describe('for a valid question', () => {
+    const data = {};
+    beforeAll((done) => {
+      Request.delete('http://localhost:4001/v1/questions/4', (error, response, body) => {
+        data.status = response.statusCode;
+        data.body = body;
+        done();
+      });
+    });
+
+    it('has respose code of 204', () => {
+      expect(data.status).toBe(204);
+    });
+
+    it('has no body', () => {
+      expect(data.body).toBe('');
+    });
+  });
+});


### PR DESCRIPTION
### **What does this PR do?**
Implement the GET one question API endpoint.

### **Description of Tasks to be completed?**
- API should be able to delete a single question when endpoint `DELETE/v1/questions/:questionId` is hit

### **How should this be manually tested?**
- Clone the repository
- Cd into it
- Checkout the **ft-delete-question-endpoint-159784945**  branch
- Run the following `npm install`, then `npm run nodemon` 
- Use postman to test the endpoint using `DELETE` at http://localhost:4001/v1/questions/:questionId

### **What are relevant pivotal tracker stories?**
[#159784945](https://www.pivotaltracker.com/n/projects/2189137)

