### PR TITLE
#159952200 Build endpoint to delete question from db

### DIFF
--- a/server/controllers/auth/index.js
+++ b/server/controllers/auth/index.js
@@ -66,6 +66,7 @@ export const logIn = async (req, res, next) => {
     if (result) {
       jwt.sign({ user }, secretKey, (err, token) => {
         user.token = token;
+        console.log(token);
       });
       res.status(200).send({
         status: 'success',

--- a/server/controllers/db/queries.js
+++ b/server/controllers/db/queries.js
@@ -112,9 +112,43 @@ export const postAnswer = async (req, res, next) => {
       });
     } catch (e) {
       res.status(400);
-      console.log(e);
+      // console.log(e);
       next(e);
     }
+  }
+};
+
+/**
+* perform database query to delete a question by Id
+* @param {object} req The request
+* @param {object} res The response
+* @param {object} next To pass onto next route
+* @returns {void}
+*/
+export const deleteQuestion = async (req, res, next) => {
+  const qId = req.params.questionId;
+  // check that question belongs to user
+  const { username } = res.locals.decoded.user;
+  const rowCount = await db.result('SELECT * FROM questions WHERE id=$1 AND "username"=$2', [qId, username], r => r.rowCount);
+  // if rowCount is greater than 0, question belongs to user.
+  if (rowCount > 0) {
+    try {
+      const result = await db.result('DELETE FROM questions WHERE id = $1', qId);
+      res.status(200).json({
+        status: 'success',
+        message: `deleted ${result.rowCount} row(s) of succesfully`,
+        id: qId,
+      });
+    } catch (e) {
+      res.status(400);
+      // console.log(e);
+      next(e);
+    }
+  } else {
+    res.status(403).json({
+      status: 'failure',
+      message: 'question not found, or user token does not match question owner',
+    });
   }
 };
 

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -16,6 +16,7 @@ import {
   getOneQuestion,
   postQuestion,
   postAnswer,
+  deleteQuestion,
 } from '../controllers/db/queries';
 
 import {
@@ -48,6 +49,8 @@ router.get('/v2/questions/:questionId', getOneQuestion); // get a single questio
 
 router.post('/v2/questions', verifyJWT, postQuestion); // post question
 router.post('/v2/questions/:questionId/answers', verifyJWT, postAnswer); // post answer
+
+router.delete('/v2/questions/:questionId', verifyJWT, deleteQuestion); // delete question
 
 
 // AUTH ROUTES


### PR DESCRIPTION
### **What does this PR do?**
Implement the DELETE a single question API endpoint.

### **Description of Tasks to be completed?**
- API should be able to delete  a single question from the database when endpoint `DELETE /v2/questions/:questionId` is hit, provided token is provided and verified.

### **How should this be manually tested?**
- Clone the repository
- Cd into it
- Checkout the **ft-get-one-endpoint-159784912**  branch
- Run the following `npm install`, then `npm run nodemon` 
- Sign up with a unique email using `POST` at http://localhost:4001/v2/auth/signup
    - refer [here](https://github.com/Darthrighteous/StackOverflow-lite/pull/21) on how to sign up
- Log in with the same detail provided signing up using 
    - refer [here](https://github.com/Darthrighteous/StackOverflow-lite/pull/22) on how to log in
- Get jwt from console
- post a question using `POST` at http://localhost:4001/v2/questions/
- get the question Id returned
- Use postman to test the endpoint using `DELETE` at http://localhost:4001/v1/questions/:questionId

### **What are relevant pivotal tracker stories?**
[#159952200](https://www.pivotaltracker.com/story/show/159952200)

